### PR TITLE
Updated libraries and tools used in the project

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
 final DAGGER_VERSION = '2.0.2'
 final DEXMAKER_VERSION = '1.2'
 final MOCKITO_VERSION = '1.10.19'
-final GOOGLE_PLAY_SERVICES_VERSION = '7.8.0'
+final GOOGLE_PLAY_SERVICES_VERSION = '8.1.0'
 final SUPPORT_LIB_VERSION = '23.0.0'
 
 dependencies {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,13 +58,13 @@ dependencies {
 
   testCompile 'junit:junit:4.12'
 
-  androidTestCompile ('com.android.support.test:runner:0.3') {
+  androidTestCompile ('com.android.support.test:runner:0.4.1') {
     exclude module: 'support-annotations'
   }
-  androidTestCompile ('com.android.support.test:rules:0.3') {
+  androidTestCompile ('com.android.support.test:rules:0.4.1') {
     exclude module: 'support-annotations'
   }
-  androidTestCompile ("com.android.support.test.espresso:espresso-core:2.2") {
+  androidTestCompile ("com.android.support.test.espresso:espresso-core:2.2.1") {
     exclude module: 'support-annotations'
   }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
   }
 }
 
-final DAGGER_VERSION = '2.0.1'
+final DAGGER_VERSION = '2.0.2'
 final DEXMAKER_VERSION = '1.2'
 final MOCKITO_VERSION = '1.10.19'
 final GOOGLE_PLAY_SERVICES_VERSION = '7.8.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ final DAGGER_VERSION = '2.0.2'
 final DEXMAKER_VERSION = '1.2'
 final MOCKITO_VERSION = '1.10.19'
 final GOOGLE_PLAY_SERVICES_VERSION = '8.1.0'
-final SUPPORT_LIB_VERSION = '23.0.0'
+final SUPPORT_LIB_VERSION = '23.1.0'
 
 dependencies {
   compile "com.google.dagger:dagger:${DAGGER_VERSION}"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,7 +50,7 @@ dependencies {
   compile "com.google.android.gms:play-services-nearby:${GOOGLE_PLAY_SERVICES_VERSION}"
 
   compile 'nl.qbusict:cupboard:2.1.2'
-  compile 'com.google.code.gson:gson:2.3.1'
+  compile 'com.google.code.gson:gson:2.4'
   compile 'com.squareup.picasso:picasso:2.5.2'
 
   compile 'com.jakewharton.timber:timber:3.1.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
 
   defaultConfig {
     applicationId 'com.sqisland.friendspell'
-    minSdkVersion 14
+    minSdkVersion 15
     targetSdkVersion 23
     versionCode 3
     versionName '1.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,16 +4,16 @@ apply plugin: 'com.google.gms.google-services'
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.2"
+  buildToolsVersion '23.0.2'
 
   defaultConfig {
-    applicationId "com.sqisland.friendspell"
+    applicationId 'com.sqisland.friendspell'
     minSdkVersion 14
     targetSdkVersion 23
     versionCode 3
-    versionName "1.0.2"
+    versionName '1.0.2'
 
-    testInstrumentationRunner "com.sqisland.friendspell.util.AndroidJacocoTestRunner"
+    testInstrumentationRunner 'com.sqisland.friendspell.util.AndroidJacocoTestRunner'
   }
 
   buildTypes {
@@ -64,7 +64,7 @@ dependencies {
   androidTestCompile ('com.android.support.test:rules:0.4.1') {
     exclude module: 'support-annotations'
   }
-  androidTestCompile ("com.android.support.test.espresso:espresso-core:2.2.1") {
+  androidTestCompile ('com.android.support.test.espresso:espresso-core:2.2.1') {
     exclude module: 'support-annotations'
   }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'com.google.gms.google-services'
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.0"
+  buildToolsVersion "23.0.2"
 
   defaultConfig {
     applicationId "com.sqisland.friendspell"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,7 +53,7 @@ dependencies {
   compile 'com.google.code.gson:gson:2.4'
   compile 'com.squareup.picasso:picasso:2.5.2'
 
-  compile 'com.jakewharton.timber:timber:3.1.0'
+  compile 'com.jakewharton.timber:timber:4.1.0'
   compile 'com.jakewharton:butterknife:7.0.1'
 
   testCompile 'junit:junit:4.12'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
   compile "com.google.android.gms:play-services-plus:${GOOGLE_PLAY_SERVICES_VERSION}"
   compile "com.google.android.gms:play-services-nearby:${GOOGLE_PLAY_SERVICES_VERSION}"
 
-  compile 'nl.qbusict:cupboard:2.1.2'
+  compile 'nl.qbusict:cupboard:2.1.4'
   compile 'com.google.code.gson:gson:2.4'
   compile 'com.squareup.picasso:picasso:2.5.2'
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:1.3.1'
-    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.7'
+    classpath 'com.neenbedankt.gradle.plugins:android-apt:1.8'
     classpath 'com.google.gms:google-services:1.3.1'
 
     // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.8-all.zip


### PR DESCRIPTION
Summarizing the updates:
- Gradle to 2.8
- android-apt plugin to 1.8
- Dagger to 2.0.2
- Google Play Services 8.1.0
- Build-Tools to 23.0.2
- Support Libs to 23.1.0
- GSON to 2.4
- Espresso to 2.2.1 and Runner/Rules to 0.4.1
- Timber to 4.1.0
- Cupboard to 2.1.4

I also turned double quotes into single quotes where they're not necessary, and bumped minSdkVersion to 15 (in fact, API 14 is not even cited into the latest dashboards (https://developer.android.com/about/dashboards/index.html) of Android, so I believe that this will not be a problem)
